### PR TITLE
Matchers need to be able to short-circuit evaluation

### DIFF
--- a/lib/rufus/decision/matcher.rb
+++ b/lib/rufus/decision/matcher.rb
@@ -30,6 +30,10 @@ module Rufus
 
       attr_accessor :options
 
+      def should_match?(cell, value)
+        nil
+      end
+
       def matches?(cell, value)
         false
       end

--- a/lib/rufus/decision/table.rb
+++ b/lib/rufus/decision/table.rb
@@ -386,7 +386,15 @@ module Decision
 
         return false unless @matchers.any? do |matcher|
           c = matcher.cell_substitution? ? Rufus::dsub(cell, hash) : cell
-          matcher.matches?(c, value)
+          should_match = matcher.should_match?(c,value)
+          case should_match
+          when NilClass, TrueClass
+            result = matcher.matches?(c, value)
+            break if !result && should_match.is_a?(TrueClass)
+            result
+          when FalseClass
+            false
+          end
         end
       end
 

--- a/test/short_circuit_matcher_test.rb
+++ b/test/short_circuit_matcher_test.rb
@@ -1,0 +1,116 @@
+require File.expand_path('../base.rb', __FILE__)
+
+
+class ShortCircuitMatcherTest < Test::Unit::TestCase
+  include DecisionTestMixin
+
+  class Matcher1 < Rufus::Decision::Matcher
+    def matches?(cell, value)
+      value.include?("aaa")
+    end
+  end
+
+  class Matcher2 < Rufus::Decision::Matcher
+    def matches?(cell, value)
+      value.include?("aa")
+    end
+  end
+
+  class ShortCircuit < Rufus::Decision::Matcher
+    def should_match?(a,b)
+      if a =~ /^short:/
+        if a =~ /:maybe:/
+          nil
+        else
+          true
+        end
+      else
+        false
+      end
+    end
+
+    def matches?(cell, value)
+      cell.gsub(/^short:(maybe:)?/, '') == value
+    end
+  end
+
+  class RaisingShortCircuit < ShortCircuit
+    def matches?(cell, value)
+      raise "No!"
+    end
+  end
+
+
+  class RaisingMatcher < Rufus::Decision::Matcher
+    def matches?(cell, value)
+      raise "No!"
+    end
+  end
+
+  def test_default_no_short_circuit
+    empty_matcher1 = Matcher1.new
+    assert ! empty_matcher1.should_match?(Object.new, Object.new)
+    empty_matcher2 = Matcher2.new
+    assert ! empty_matcher2.should_match?(Object.new, Object.new)
+
+    table = Rufus::Decision::Table.new(%Q{
+      in:first_col,out:second_col
+      anything, works
+    })
+
+    table.matchers = [empty_matcher1, empty_matcher2]
+    
+    wi = { 'first_col' => 'aa' }
+    do_test(table, wi, { "second_col" => "works" }, false)
+
+  end
+
+
+  def test_short_circuit
+
+    table = Rufus::Decision::Table.new(%Q{
+      in:first_col,out:second_col
+      short:aaa, works
+    })
+
+    table.matchers = [
+      ShortCircuit.new,
+      RaisingMatcher.new
+    ]
+    
+    wi = { 'first_col' => 'aa' }
+    assert_nothing_raised{ table.transform wi }
+
+    do_test(table, wi, { }, false)
+
+    wi = { 'first_col' => 'aaa' }
+    assert_nothing_raised{ table.transform wi }
+
+    do_test(table, wi, {'second_col' => 'works' }, false)
+
+  end
+
+  def test_short_circuit_maybe
+
+    table = Rufus::Decision::Table.new(%Q{
+      in:first_col,out:second_col
+      short:maybe:aaa, works
+    })
+
+    table.matchers = [
+      ShortCircuit.new,
+      RaisingMatcher.new
+    ]
+    
+    wi = { 'first_col' => 'aa' }
+    assert_raise(RuntimeError){ table.transform wi }
+
+
+    wi = { 'first_col' => 'aaa' }
+    assert_nothing_raised{ table.transform wi }
+
+    do_test(table, wi, {'second_col' => 'works' }, false)
+  end
+
+end
+


### PR DESCRIPTION
If a matcher does not match a cell, but is the correct matcher that COULD match the cell, it needs to be able to tell rufus-decision this so that rufus-decision does not run subsequent matchers.

There are three ways I see to do this:
1. give Rufus::Decision::Matcher a should_match? method. The evaluation loop would call this on the matcher first. It should return a 3-state boolean (true, false or nil):
   - if true --> run matcher.matches? and don't run any other matchers regardless of result
   - if false -> don't run matcher.matches? and continue running other matchers
   - if nil -> run matcher.matches? and continue running other matches if it returns false
     This option means we would not have to touch the current matchers.
2. The second way would be to use similar logic but have matches? return the 3-state boolean. This however means that all matchers have to be aware of the contract.
3. The third way is to have matches? raise an exception in order to short circuit further matching. This is good architecturally, but expensive.

I prefer 1). 

Let me know if you see a good reason to prefer one of the other ways, otherwise I will go ahead and implement 1) and submit as a pull request.
